### PR TITLE
Use ParseResponseForCert for parsing certificates

### DIFF
--- a/certstatus.go
+++ b/certstatus.go
@@ -162,7 +162,7 @@ func getOCSPResponse(cert *x509.Certificate) (*ocsp.Response, error) {
 		os.Exit(1)
 	}
 
-	parsedResponse, err := ocsp.ParseResponse(body, issuer)
+	parsedResponse, err := ocsp.ParseResponseForCert(body, cert, issuer)
 
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "[error] %v\n", err)


### PR DESCRIPTION
In contrast to `ParseResponse`, `ParseResponseForCert` does check that the OCSP
response matches the provided certificate.

See: https://github.com/golang/crypto/blob/bd6f299fb381e4c3393d1c4b1f0b94f5e77650c8/ocsp/ocsp.go#L504-L513